### PR TITLE
Fix missing player palette in overworld palettes.

### DIFF
--- a/smwe_rom/src/error.rs
+++ b/smwe_rom/src/error.rs
@@ -33,21 +33,17 @@ pub enum GfxTileError {
 }
 
 #[derive(Debug, Error)]
-pub enum LevelPaletteError {
+pub enum ColorPaletteError {
     #[error("Failed to construct a level's back area color.")]
-    BackAreaColor,
+    LvBackAreaColor,
     #[error("Failed to construct a level's background palette.")]
-    Background,
+    LvBackground,
     #[error("Failed to construct a level's foreground palette.")]
-    Foreground,
+    LvForeground,
     #[error("Failed to construct a level's sprite palette.")]
-    Sprite,
-}
-
-#[derive(Debug, Error)]
-pub enum OverworldSubmapPaletteError {
+    LvSprite,
     #[error("Failed to construct an overworld submap's layer 2 palette.")]
-    Layer2,
+    OwLayer2,
 }
 
 #[derive(Debug, Error)]
@@ -64,14 +60,8 @@ pub enum RomParseError {
     IoError,
     #[error("Invalid level: {0:#X}")]
     Level(usize),
-    #[error("Could not parse global level color palette")]
-    PaletteGlobalLevel,
-    #[error("Could not parse global overworld color palette")]
-    PaletteGlobalOverworld,
-    #[error("Invalid color palette in level {0:#X}")]
-    PaletteSetLevel(usize),
-    #[error("Invalid color palette in overworld")]
-    PaletteSetOverworld,
+    #[error("Could not parse color palettes")]
+    ColorPalettes,
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/smwe_rom/src/graphics/palette.rs
+++ b/smwe_rom/src/graphics/palette.rs
@@ -132,7 +132,7 @@ pub struct ColorPalettes {
     pub ow_layer3: Box<[Abgr1555]>,
     pub ow_sprite: Box<[Abgr1555]>,
 
-    pub lv_wtf:      Box<[Abgr1555]>,
+    pub wtf:      Box<[Abgr1555]>,
     pub lv_layer3:   Box<[Abgr1555]>,
     pub lv_berry:    Box<[Abgr1555]>,
     pub lv_animated: Box<[Abgr1555]>,
@@ -176,6 +176,7 @@ pub struct SpecificOverworldColorPalette {
     pub layer3:  Box<[Abgr1555]>,
     pub sprite:  Box<[Abgr1555]>,
     pub players: Box<[Abgr1555]>,
+    pub wtf:     Box<[Abgr1555]>,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
@@ -233,7 +234,7 @@ impl ColorPalettes {
             ow_layer1: ow_layer1_colors.into(),
             ow_layer3: ow_layer3_colors.into(),
             ow_sprite: ow_sprite_colors.into(),
-            lv_wtf: lv_wtf.into(),
+            wtf: lv_wtf.into(),
             lv_layer3: lv_layer3.into(),
             lv_berry: lv_berry.into(),
             lv_animated: lv_animated.into(),
@@ -331,7 +332,7 @@ impl LevelColorPaletteSet {
             background:      self.bg_palettes.get(i_background).cloned().ok_or(ColorPaletteError::LvBackground)?,
             foreground:      self.fg_palettes.get(i_foreground).cloned().ok_or(ColorPaletteError::LvForeground)?,
             sprite:          self.sprite_palettes.get(i_sprite).cloned().ok_or(ColorPaletteError::LvSprite)?,
-            wtf:             palettes.lv_wtf.clone(),
+            wtf:             palettes.wtf.clone(),
             layer3:          palettes.lv_layer3.clone(),
             berry:           palettes.lv_berry.clone(),
             animated:        palettes.lv_animated.clone(),
@@ -386,19 +387,22 @@ impl OverworldColorPaletteSet {
     pub fn get_submap_palette_from_indices(
         &self, i_submap_palette: usize, ow_state: OverworldState, palettes: &ColorPalettes,
     ) -> Result<SpecificOverworldColorPalette, ColorPaletteError> {
-        Ok(SpecificOverworldColorPalette {
+        let mut palette = SpecificOverworldColorPalette {
             layer1:  palettes.ow_layer1.clone(),
             layer2:  match ow_state {
                 OverworldState::PreSpecial => &self.layer2_pre_special,
                 OverworldState::PostSpecial => &self.layer2_post_special,
             }
-            .get(i_submap_palette)
-            .cloned()
-            .ok_or(ColorPaletteError::OwLayer2)?,
+                .get(i_submap_palette)
+                .cloned()
+                .ok_or(ColorPaletteError::OwLayer2)?,
             layer3:  palettes.ow_layer3.clone(),
             sprite:  palettes.ow_sprite.clone(),
             players: palettes.players.clone(),
-        })
+            wtf:     palettes.wtf.clone()[23..=27].into(),
+        };
+        palette.wtf[0] = Abgr1555::WHITE;
+        Ok(palette)
     }
 }
 
@@ -420,4 +424,5 @@ impl_color_palette!(SpecificOverworldColorPalette {
     [0x0..=0x1, 0x8..=0xF] => layer3,
     [0x9..=0xF, 0x1..=0x7] => sprite,
     [0x8..=0x8, 0x6..=0xF] => players,
+    [0x8..=0x8, 0x1..=0x5] => wtf,
 });

--- a/smwe_rom/src/graphics/palette.rs
+++ b/smwe_rom/src/graphics/palette.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryInto, ops::RangeInclusive, rc::Rc};
+use std::{convert::TryInto, ops::RangeInclusive};
 
 use nom::{
     count,
@@ -13,7 +13,7 @@ use nom::{
 use self::constants::*;
 use crate::{
     addr::{AddrPc, AddrSnes},
-    error::{LevelPaletteError, OverworldSubmapPaletteError, RomParseError},
+    error::{ColorPaletteError, RomParseError},
     graphics::color::{Abgr1555, BGR555_SIZE},
     level::{primary_header::PrimaryHeader, Level},
 };
@@ -81,7 +81,7 @@ pub trait ColorPalette {
 macro_rules! impl_color_palette {
     ($struct_name:ident {
         $([$rows:expr, $cols:expr] => $field_name:ident),+
-        $(, _ => $fallback:ident)? $(,)?
+        $(, default_color_1 => $default_color_1:expr)? $(,)?
     }) => {
         impl ColorPalette for $struct_name {
             fn set_color_at(&mut self, row: usize, col: usize, color: Abgr1555) {
@@ -95,21 +95,12 @@ macro_rules! impl_color_palette {
                         return;
                     }
                 )+
-                $(
-                    if let Some(fb) = Rc::get_mut(&mut self.$fallback) {
-                        fb.set_color_at(row, col, color);
-                    }
-                )?
             }
 
             #[allow(unreachable_code)]
             fn get_color_at(&self, row: usize, col: usize) -> Option<Abgr1555> {
                 if row > 0xF || col > 0xF {
                     None
-                } else if col == 0 {
-                    Some(Abgr1555::TRANSPARENT)
-                } else if col == 1 {
-                    Some(Abgr1555::WHITE)
                 } else {
                     $(
                         if $rows.contains(&row) && $cols.contains(&col) {
@@ -118,8 +109,13 @@ macro_rules! impl_color_palette {
                             return Some(self.$field_name[(ri * $cols.count()) + ci]);
                         }
                     )+
-                    $(return self.$fallback.get_color_at(row, col);)?
-                    Some(Abgr1555::TRANSPARENT)
+                    $(if col == 0 {
+                        Some(Abgr1555::TRANSPARENT)
+                    } else if col == 1 {
+                        Some($default_color_1)
+                    } else)? {
+                        Some(Abgr1555::TRANSPARENT)
+                    }
                 }
             }
         }
@@ -129,21 +125,27 @@ macro_rules! impl_color_palette {
 // -------------------------------------------------------------------------------------------------
 
 #[derive(Clone)]
-pub struct GlobalLevelColorPalette {
-    pub wtf:      Box<[Abgr1555]>,
-    pub players:  Box<[Abgr1555]>,
-    pub layer3:   Box<[Abgr1555]>,
-    pub berry:    Box<[Abgr1555]>,
-    pub animated: Box<[Abgr1555]>,
+pub struct ColorPalettes {
+    pub players: Box<[Abgr1555]>,
+
+    pub ow_layer1: Box<[Abgr1555]>,
+    pub ow_layer3: Box<[Abgr1555]>,
+    pub ow_sprite: Box<[Abgr1555]>,
+
+    pub lv_wtf:      Box<[Abgr1555]>,
+    pub lv_layer3:   Box<[Abgr1555]>,
+    pub lv_berry:    Box<[Abgr1555]>,
+    pub lv_animated: Box<[Abgr1555]>,
+
+    pub ow_specific_set: OverworldColorPaletteSet,
+    pub lv_specific_set: LevelColorPaletteSet,
 }
 
 #[derive(Clone)]
-pub struct LevelColorPalette {
-    pub global_palette:  Rc<GlobalLevelColorPalette>,
-    pub back_area_color: Abgr1555,
-    pub background:      Box<[Abgr1555]>,
-    pub foreground:      Box<[Abgr1555]>,
-    pub sprite:          Box<[Abgr1555]>,
+pub struct OverworldColorPaletteSet {
+    pub layer2_pre_special:  Vec<Box<[Abgr1555]>>,
+    pub layer2_post_special: Vec<Box<[Abgr1555]>>,
+    pub layer2_indices:      Vec<usize>,
 }
 
 #[derive(Clone)]
@@ -155,23 +157,25 @@ pub struct LevelColorPaletteSet {
 }
 
 #[derive(Clone)]
-pub struct GlobalOverworldColorPalette {
-    pub layer1: Box<[Abgr1555]>,
-    pub layer3: Box<[Abgr1555]>,
-    pub sprite: Box<[Abgr1555]>,
+pub struct SpecificLevelColorPalette {
+    pub back_area_color: Abgr1555,
+    pub background:      Box<[Abgr1555]>,
+    pub foreground:      Box<[Abgr1555]>,
+    pub sprite:          Box<[Abgr1555]>,
+    pub players:         Box<[Abgr1555]>,
+    pub wtf:             Box<[Abgr1555]>,
+    pub layer3:          Box<[Abgr1555]>,
+    pub berry:           Box<[Abgr1555]>,
+    pub animated:        Box<[Abgr1555]>,
 }
 
 #[derive(Clone)]
-pub struct OverworldSubmapColorPalette {
-    pub global_palette: Rc<GlobalOverworldColorPalette>,
-    pub layer2:         Box<[Abgr1555]>,
-}
-
-#[derive(Clone)]
-pub struct OverworldColorPaletteSet {
-    pub layer2_pre_special:  Vec<Box<[Abgr1555]>>,
-    pub layer2_post_special: Vec<Box<[Abgr1555]>>,
-    pub layer2_indices:      Vec<usize>,
+pub struct SpecificOverworldColorPalette {
+    pub layer1:  Box<[Abgr1555]>,
+    pub layer2:  Box<[Abgr1555]>,
+    pub layer3:  Box<[Abgr1555]>,
+    pub sprite:  Box<[Abgr1555]>,
+    pub players: Box<[Abgr1555]>,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
@@ -193,64 +197,64 @@ fn make_color_parser<'r>(rom_data: &'r [u8]) -> impl Fn(AddrSnes, usize) -> Colo
     }
 }
 
-impl GlobalLevelColorPalette {
-    pub fn parse(rom_data: &[u8]) -> Result<GlobalLevelColorPalette, RomParseError> {
-        match Self::parse_impl(rom_data) {
+impl ColorPalettes {
+    pub fn parse(rom_data: &[u8], levels: &[Level]) -> Result<Self, RomParseError> {
+        match Self::parse_impl(rom_data, levels) {
             Ok((_, palette_set)) => Ok(palette_set),
-            Err(_) => Err(RomParseError::PaletteGlobalLevel),
+            Err(_) => Err(RomParseError::ColorPalettes),
         }
     }
 
-    fn parse_impl(rom_data: &[u8]) -> IResult<&[u8], GlobalLevelColorPalette> {
-        const WTF_PALETTE: AddrSnes = AddrSnes(0x00B250);
+    fn parse_impl<'r>(rom_data: &'r [u8], levels: &[Level]) -> IResult<&'r [u8], Self> {
         const PLAYER_PALETTE: AddrSnes = AddrSnes(0x00B2C8);
-        const LAYER3_PALETTE: AddrSnes = AddrSnes(0x00B170);
-        const BERRY_PALETTE: AddrSnes = AddrSnes(0x00B674);
-        const ANIMATED_COLOR: AddrSnes = AddrSnes(0x00B60C);
+        const OW_LAYER1_PALETTES: AddrSnes = AddrSnes(0x00B528);
+        const OW_LAYER3_PALETTES: AddrSnes = AddrSnes(0x00B5EC);
+        const OW_SPRITE_PALETTES: AddrSnes = AddrSnes(0x00B58A);
+        const LV_WTF_PALETTE: AddrSnes = AddrSnes(0x00B250);
+        const LV_LAYER3_PALETTE: AddrSnes = AddrSnes(0x00B170);
+        const LV_BERRY_PALETTE: AddrSnes = AddrSnes(0x00B674);
+        const LV_ANIMATED_COLOR: AddrSnes = AddrSnes(0x00B60C);
 
         let parse_colors = make_color_parser(rom_data);
 
-        let (_, wtf) = parse_colors(WTF_PALETTE, PALETTE_WTF_LENGTH)?;
         let (_, players) = parse_colors(PLAYER_PALETTE, PALETTE_PLAYER_LENGTH)?;
-        let (_, layer3) = parse_colors(LAYER3_PALETTE, PALETTE_LAYER3_LENGTH)?;
-        let (_, berry) = parse_colors(BERRY_PALETTE, PALETTE_BERRY_LENGTH)?;
-        let (_, animated) = parse_colors(ANIMATED_COLOR, PALETTE_ANIMATED_LENGTH)?;
+        let (_, ow_layer1_colors) = parse_colors(OW_LAYER1_PALETTES, OW_LAYER1_PALETTE_LENGTH)?;
+        let (_, ow_layer3_colors) = parse_colors(OW_LAYER3_PALETTES, OW_LAYER3_PALETTE_LENGTH)?;
+        let (_, ow_sprite_colors) = parse_colors(OW_SPRITE_PALETTES, OW_SPRITE_PALETTE_LENGTH)?;
+        let (_, lv_wtf) = parse_colors(LV_WTF_PALETTE, PALETTE_WTF_LENGTH)?;
+        let (_, lv_layer3) = parse_colors(LV_LAYER3_PALETTE, PALETTE_LAYER3_LENGTH)?;
+        let (_, lv_berry) = parse_colors(LV_BERRY_PALETTE, PALETTE_BERRY_LENGTH)?;
+        let (_, lv_animated) = parse_colors(LV_ANIMATED_COLOR, PALETTE_ANIMATED_LENGTH)?;
+        let (_, lv_specific_set) = LevelColorPaletteSet::parse(rom_data, levels)?;
+        let (_, ow_specific_set) = OverworldColorPaletteSet::parse(rom_data)?;
 
-        let mut palette = GlobalLevelColorPalette {
-            wtf:      [Abgr1555::default(); PALETTE_WTF_LENGTH].into(),
-            players:  [Abgr1555::default(); PALETTE_PLAYER_LENGTH].into(),
-            layer3:   [Abgr1555::default(); PALETTE_LAYER3_LENGTH].into(),
-            berry:    [Abgr1555::default(); PALETTE_BERRY_LENGTH].into(),
-            animated: [Abgr1555::default(); PALETTE_ANIMATED_LENGTH].into(),
-        };
-
-        palette.set_colors(&wtf, 0x4..=0xD, 0x2..=0x7);
-        palette.players = players.try_into().unwrap(); // 0x8..=0x8, 0x6..=0xF
-        palette.set_colors(&layer3, 0x0..=0x1, 0x8..=0xF);
-        palette.set_colors(&berry, 0x2..=0x4, 0x9..=0xF);
-        palette.set_colors(&berry, 0x9..=0xB, 0x9..=0xF);
-        palette.animated = animated.try_into().unwrap(); // 0x6, 0x4
-
-        Ok((rom_data, palette))
+        Ok((rom_data, ColorPalettes {
+            players: players.into(),
+            ow_layer1: ow_layer1_colors.into(),
+            ow_layer3: ow_layer3_colors.into(),
+            ow_sprite: ow_sprite_colors.into(),
+            lv_wtf: lv_wtf.into(),
+            lv_layer3: lv_layer3.into(),
+            lv_berry: lv_berry.into(),
+            lv_animated: lv_animated.into(),
+            ow_specific_set,
+            lv_specific_set,
+        }))
     }
 
-    pub fn is_animated_color_at(&self, row: usize, col: usize) -> bool {
-        (row == 0x6) && (col == 0x4)
+    pub fn get_level_palette(&self, header: &PrimaryHeader) -> Result<SpecificLevelColorPalette, ColorPaletteError> {
+        self.lv_specific_set.get_level_palette(header, &self)
+    }
+
+    pub fn get_submap_palette(
+        &self, submap: usize, ow_state: OverworldState,
+    ) -> Result<SpecificOverworldColorPalette, ColorPaletteError> {
+        self.ow_specific_set.get_submap_palette(submap, ow_state, &self)
     }
 }
 
 impl LevelColorPaletteSet {
-    pub fn parse(rom_data: &[u8], levels: &[Level]) -> Result<LevelColorPaletteSet, RomParseError> {
-        let mut lvl_num = 0;
-        match Self::parse_impl(rom_data, levels, &mut lvl_num) {
-            Ok((_, palette_set)) => Ok(palette_set),
-            Err(_) => Err(RomParseError::PaletteSetLevel(lvl_num)),
-        }
-    }
-
-    fn parse_impl<'a>(
-        rom_data: &'a [u8], levels: &[Level], lvl_num: &mut usize,
-    ) -> IResult<&'a [u8], LevelColorPaletteSet> {
+    fn parse<'a>(rom_data: &'a [u8], levels: &[Level]) -> IResult<&'a [u8], LevelColorPaletteSet> {
         const BACK_AREA_COLORS: AddrSnes = AddrSnes(0x00B0A0);
         const BG_PALETTES: AddrSnes = AddrSnes(0x00B0B0);
         const FG_PALETTES: AddrSnes = AddrSnes(0x00B190);
@@ -265,7 +269,6 @@ impl LevelColorPaletteSet {
             sprite_palettes:  Vec::with_capacity(8),
         };
 
-        *lvl_num = 0;
         for level in levels {
             let header = &level.primary_header;
 
@@ -300,77 +303,45 @@ impl LevelColorPaletteSet {
             palette_set.bg_palettes[idx_bg] = bg.try_into().unwrap();
             palette_set.fg_palettes[idx_fg] = fg.try_into().unwrap();
             palette_set.sprite_palettes[idx_sp] = sp.try_into().unwrap();
-
-            *lvl_num += 1;
         }
 
         Ok((rom_data, palette_set))
     }
 
     pub fn get_level_palette(
-        &self, header: &PrimaryHeader, gp: &Rc<GlobalLevelColorPalette>,
-    ) -> Result<LevelColorPalette, LevelPaletteError> {
+        &self, header: &PrimaryHeader, palettes: &ColorPalettes,
+    ) -> Result<SpecificLevelColorPalette, ColorPaletteError> {
         let i_back_area_color = header.back_area_color as usize;
         let i_background = header.palette_bg as usize;
         let i_foreground = header.palette_fg as usize;
         let i_sprite = header.palette_sprite as usize;
-        self.palette_from_indices(i_back_area_color, i_background, i_foreground, i_sprite, gp)
+        self.palette_from_indices(i_back_area_color, i_background, i_foreground, i_sprite, palettes)
     }
 
     pub fn palette_from_indices(
         &self, i_back_area_color: usize, i_background: usize, i_foreground: usize, i_sprite: usize,
-        gp: &Rc<GlobalLevelColorPalette>,
-    ) -> Result<LevelColorPalette, LevelPaletteError> {
-        Ok(LevelColorPalette {
-            global_palette:  Rc::clone(gp),
+        palettes: &ColorPalettes,
+    ) -> Result<SpecificLevelColorPalette, ColorPaletteError> {
+        Ok(SpecificLevelColorPalette {
             back_area_color: self
                 .back_area_colors
                 .get(i_back_area_color)
                 .cloned()
-                .ok_or(LevelPaletteError::BackAreaColor)?,
-            background:      self.bg_palettes.get(i_background).cloned().ok_or(LevelPaletteError::Background)?,
-            foreground:      self.fg_palettes.get(i_foreground).cloned().ok_or(LevelPaletteError::Foreground)?,
-            sprite:          self.sprite_palettes.get(i_sprite).cloned().ok_or(LevelPaletteError::Sprite)?,
+                .ok_or(ColorPaletteError::LvBackAreaColor)?,
+            background:      self.bg_palettes.get(i_background).cloned().ok_or(ColorPaletteError::LvBackground)?,
+            foreground:      self.fg_palettes.get(i_foreground).cloned().ok_or(ColorPaletteError::LvForeground)?,
+            sprite:          self.sprite_palettes.get(i_sprite).cloned().ok_or(ColorPaletteError::LvSprite)?,
+            wtf:             palettes.lv_wtf.clone(),
+            layer3:          palettes.lv_layer3.clone(),
+            berry:           palettes.lv_berry.clone(),
+            animated:        palettes.lv_animated.clone(),
+            players:         palettes.players.clone(),
         })
     }
 }
 
-impl GlobalOverworldColorPalette {
-    pub fn parse(rom_data: &[u8]) -> Result<GlobalOverworldColorPalette, RomParseError> {
-        match Self::parse_impl(rom_data) {
-            Ok((_, palette_set)) => Ok(palette_set),
-            Err(_) => Err(RomParseError::PaletteGlobalOverworld),
-        }
-    }
-
-    fn parse_impl(rom_data: &[u8]) -> IResult<&[u8], GlobalOverworldColorPalette> {
-        let parse_colors = make_color_parser(rom_data);
-
-        const LAYER1_PALETTES: AddrSnes = AddrSnes(0x00B528);
-        const LAYER3_PALETTES: AddrSnes = AddrSnes(0x00B5EC);
-        const SPRITE_PALETTES: AddrSnes = AddrSnes(0x00B58A);
-
-        let (_, layer1_colors) = parse_colors(LAYER1_PALETTES, OW_LAYER1_PALETTE_LENGTH)?;
-        let (_, layer3_colors) = parse_colors(LAYER3_PALETTES, OW_LAYER3_PALETTE_LENGTH)?;
-        let (_, sprite_colors) = parse_colors(SPRITE_PALETTES, OW_SPRITE_PALETTE_LENGTH)?;
-
-        Ok((rom_data, GlobalOverworldColorPalette {
-            layer1: layer1_colors.into(),
-            layer3: layer3_colors.into(),
-            sprite: sprite_colors.into(),
-        }))
-    }
-}
-
 impl OverworldColorPaletteSet {
-    pub fn parse(rom_data: &[u8]) -> Result<OverworldColorPaletteSet, RomParseError> {
-        match Self::parse_impl(rom_data) {
-            Ok((_, palette_set)) => Ok(palette_set),
-            Err(_) => Err(RomParseError::PaletteSetOverworld),
-        }
-    }
-
-    fn parse_impl(rom_data: &[u8]) -> IResult<&[u8], OverworldColorPaletteSet> {
+    fn parse(rom_data: &[u8]) -> IResult<&[u8], OverworldColorPaletteSet> {
         let parse_colors = make_color_parser(rom_data);
 
         const LAYER2_NORMAL_PALETTES: AddrSnes = AddrSnes(0x00B3D8);
@@ -406,50 +377,47 @@ impl OverworldColorPaletteSet {
     }
 
     pub fn get_submap_palette(
-        &self, submap: usize, ow_state: OverworldState, gp: &Rc<GlobalOverworldColorPalette>,
-    ) -> Result<OverworldSubmapColorPalette, OverworldSubmapPaletteError> {
-        let i_submap_palette = *self.layer2_indices.get(submap).ok_or(OverworldSubmapPaletteError::Layer2)?;
-        self.get_submap_palette_from_indices(i_submap_palette, ow_state, gp)
+        &self, submap: usize, ow_state: OverworldState, palettes: &ColorPalettes,
+    ) -> Result<SpecificOverworldColorPalette, ColorPaletteError> {
+        let i_submap_palette = *self.layer2_indices.get(submap).ok_or(ColorPaletteError::OwLayer2)?;
+        self.get_submap_palette_from_indices(i_submap_palette, ow_state, palettes)
     }
 
     pub fn get_submap_palette_from_indices(
-        &self, i_submap_palette: usize, ow_state: OverworldState, gp: &Rc<GlobalOverworldColorPalette>,
-    ) -> Result<OverworldSubmapColorPalette, OverworldSubmapPaletteError> {
-        Ok(OverworldSubmapColorPalette {
-            global_palette: Rc::clone(gp),
-            layer2:         match ow_state {
+        &self, i_submap_palette: usize, ow_state: OverworldState, palettes: &ColorPalettes,
+    ) -> Result<SpecificOverworldColorPalette, ColorPaletteError> {
+        Ok(SpecificOverworldColorPalette {
+            layer1:  palettes.ow_layer1.clone(),
+            layer2:  match ow_state {
                 OverworldState::PreSpecial => &self.layer2_pre_special,
                 OverworldState::PostSpecial => &self.layer2_post_special,
             }
             .get(i_submap_palette)
             .cloned()
-            .ok_or(OverworldSubmapPaletteError::Layer2)?,
+            .ok_or(ColorPaletteError::OwLayer2)?,
+            layer3:  palettes.ow_layer3.clone(),
+            sprite:  palettes.ow_sprite.clone(),
+            players: palettes.players.clone(),
         })
     }
 }
 
-impl_color_palette!(GlobalLevelColorPalette {
-    [0x8..=0x8, 0x6..=0xF] => players,
-    [0x0..=0x1, 0x8..=0xF] => layer3,
-    [0x2..=0x4, 0x9..=0xF] => berry,
-    [0x9..=0xB, 0x9..=0xF] => berry,
-    [0x4..=0xD, 0x2..=0x7] => wtf,
-});
-
-impl_color_palette!(LevelColorPalette {
+impl_color_palette!(SpecificLevelColorPalette {
     [0x0..=0x1, 0x2..=0x7] => background,
     [0x2..=0x3, 0x2..=0x7] => foreground,
     [0xE..=0xF, 0x2..=0x7] => sprite,
-    _ => global_palette,
+    [0x4..=0xD, 0x2..=0x7] => wtf,
+    [0x0..=0x1, 0x8..=0xF] => layer3,
+    [0x2..=0x4, 0x9..=0xF] => berry,
+    [0x9..=0xB, 0x9..=0xF] => berry,
+    [0x8..=0x8, 0x6..=0xF] => players,
+    default_color_1 => Abgr1555::WHITE,
 });
 
-impl_color_palette!(GlobalOverworldColorPalette {
+impl_color_palette!(SpecificOverworldColorPalette {
     [0x2..=0x7, 0x9..=0xF] => layer1,
+    [0x4..=0x7, 0x1..=0x7] => layer2,
     [0x0..=0x1, 0x8..=0xF] => layer3,
     [0x9..=0xF, 0x1..=0x7] => sprite,
-});
-
-impl_color_palette!(OverworldSubmapColorPalette {
-    [0x4..=0x7, 0x1..=0x7] => layer2,
-    _ => global_palette,
+    [0x8..=0x8, 0x6..=0xF] => players,
 });

--- a/smwe_rom/src/graphics/palette.rs
+++ b/smwe_rom/src/graphics/palette.rs
@@ -132,7 +132,7 @@ pub struct ColorPalettes {
     pub ow_layer3: Box<[Abgr1555]>,
     pub ow_sprite: Box<[Abgr1555]>,
 
-    pub wtf:      Box<[Abgr1555]>,
+    pub wtf:         Box<[Abgr1555]>,
     pub lv_layer3:   Box<[Abgr1555]>,
     pub lv_berry:    Box<[Abgr1555]>,
     pub lv_animated: Box<[Abgr1555]>,
@@ -393,9 +393,9 @@ impl OverworldColorPaletteSet {
                 OverworldState::PreSpecial => &self.layer2_pre_special,
                 OverworldState::PostSpecial => &self.layer2_post_special,
             }
-                .get(i_submap_palette)
-                .cloned()
-                .ok_or(ColorPaletteError::OwLayer2)?,
+            .get(i_submap_palette)
+            .cloned()
+            .ok_or(ColorPaletteError::OwLayer2)?,
             layer3:  palettes.ow_layer3.clone(),
             sprite:  palettes.ow_sprite.clone(),
             players: palettes.players.clone(),

--- a/src/ui/dev_utils/gfx_viewer.rs
+++ b/src/ui/dev_utils/gfx_viewer.rs
@@ -199,13 +199,14 @@ impl UiGfxViewer {
             let rom = &project.rom_data;
             let gfx_file = &rom.gfx_files[self.curr_gfx_file_num as usize];
             let palette = &rom
-                .level_color_palette_set
+                .color_palettes
+                .lv_specific_set
                 .palette_from_indices(
                     0,
                     self.curr_bg_palette_num as usize,
                     self.curr_fg_palette_num as usize,
                     self.curr_sp_palette_num as usize,
-                    &rom.global_level_color_palette,
+                    &rom.color_palettes,
                 )
                 .unwrap()
                 .get_row(self.curr_palette_row_idx as usize);
@@ -241,16 +242,16 @@ impl UiGfxViewer {
             let palette_row_count = 16i32;
             self.curr_palette_row_idx = self.curr_palette_row_idx.rem_euclid(palette_row_count);
 
-            let bg_pals_count = rom.level_color_palette_set.bg_palettes.len() as i32;
+            let bg_pals_count = rom.color_palettes.lv_specific_set.bg_palettes.len() as i32;
             self.curr_bg_palette_num = self.curr_bg_palette_num.rem_euclid(bg_pals_count);
 
-            let fg_pals_count = rom.level_color_palette_set.fg_palettes.len() as i32;
+            let fg_pals_count = rom.color_palettes.lv_specific_set.fg_palettes.len() as i32;
             self.curr_fg_palette_num = self.curr_fg_palette_num.rem_euclid(fg_pals_count);
 
-            let sp_pals_count = rom.level_color_palette_set.sprite_palettes.len() as i32;
+            let sp_pals_count = rom.color_palettes.lv_specific_set.sprite_palettes.len() as i32;
             self.curr_sp_palette_num = self.curr_sp_palette_num.rem_euclid(sp_pals_count);
 
-            let pl_pals_count = rom.global_level_color_palette.players.len() as i32 / 10;
+            let pl_pals_count = rom.color_palettes.players.len() as i32 / 10;
             self.curr_pl_palette_num = self.curr_pl_palette_num.rem_euclid(pl_pals_count);
         }
     }

--- a/src/ui/dev_utils/palette_viewer.rs
+++ b/src/ui/dev_utils/palette_viewer.rs
@@ -79,7 +79,7 @@ impl UiPaletteViewer {
 
     fn adjust_ow_submap_num(&mut self, ctx: &mut FrameContext) {
         let project = ctx.project_ref.as_ref().unwrap().borrow();
-        let submap_count = project.rom_data.overworld_color_palette_set.layer2_indices.len() as i32;
+        let submap_count = project.rom_data.color_palettes.ow_specific_set.layer2_indices.len() as i32;
         self.submap_num = self.submap_num.rem_euclid(submap_count);
     }
 
@@ -106,6 +106,26 @@ impl UiPaletteViewer {
         self.display_overworld_palette(ctx);
     }
 
+    fn display_level_palette(&mut self, ctx: &mut FrameContext) {
+        let FrameContext { ui, project_ref, .. } = ctx;
+        let project = project_ref.as_ref().unwrap().borrow();
+        let rom = &project.rom_data;
+
+        let header = &rom.levels[self.level_num as usize].primary_header;
+        let palette = &rom.color_palettes.get_level_palette(header).unwrap();
+        self.display_palette(ui, palette);
+    }
+
+    fn display_overworld_palette(&mut self, ctx: &mut FrameContext) {
+        let FrameContext { ui, project_ref, .. } = ctx;
+        let project = project_ref.as_ref().unwrap().borrow();
+        let rom = &project.rom_data;
+
+        let ow_state = if self.special_completed { OverworldState::PostSpecial } else { OverworldState::PreSpecial };
+        let palette = &rom.color_palettes.get_submap_palette(self.submap_num as usize, ow_state).unwrap();
+        self.display_palette(ui, palette);
+    }
+
     fn display_palette(&mut self, ui: &Ui, palette: &dyn ColorPalette) {
         const CELL_SIZE: f32 = 20.0;
 
@@ -127,28 +147,5 @@ impl UiPaletteViewer {
             }
         }
         ui.set_cursor_screen_pos([wx + 16.0 * CELL_SIZE, wy + 16.0 * CELL_SIZE]);
-    }
-
-    fn display_level_palette(&mut self, ctx: &mut FrameContext) {
-        let FrameContext { ui, project_ref, .. } = ctx;
-        let project = project_ref.as_ref().unwrap().borrow();
-        let rom = &project.rom_data;
-
-        let header = &rom.levels[self.level_num as usize].primary_header;
-        let palette = &rom.level_color_palette_set.get_level_palette(header, &rom.global_level_color_palette).unwrap();
-        self.display_palette(ui, palette);
-    }
-
-    fn display_overworld_palette(&mut self, ctx: &mut FrameContext) {
-        let FrameContext { ui, project_ref, .. } = ctx;
-        let project = project_ref.as_ref().unwrap().borrow();
-        let rom = &project.rom_data;
-
-        let ow_state = if self.special_completed { OverworldState::PostSpecial } else { OverworldState::PreSpecial };
-        let palette = &rom
-            .overworld_color_palette_set
-            .get_submap_palette(self.submap_num as usize, ow_state, &rom.global_overworld_color_palette)
-            .unwrap();
-        self.display_palette(ui, palette);
     }
 }


### PR DESCRIPTION
I rearranged the storage of all colour palettes so that it's easier to share global palettes between level- and submap-specific palette sets. This also simplified the palette hierarchy as fewer structs became necessary and specific palettes are now decoupled from the global ones (new each holds their own copy of the colours).