### PR TITLE
Fix parsing GFX, extend error reporting for decompression

### DIFF
--- a/smwe_rom/src/compression/lc_lz2.rs
+++ b/smwe_rom/src/compression/lc_lz2.rs
@@ -51,8 +51,8 @@ pub fn decompress(input: &[u8]) -> Result<Vec<u8>, LcLz2Error> {
 
         if let Command::LongLength = command {
             let real_command_bits = (chunk_header >> 2) & 0b111;
-            command = Command::try_from(real_command_bits)
-                .map_err(|_| LcLz2Error::LongLengthCommand(real_command_bits))?;
+            command =
+                Command::try_from(real_command_bits).map_err(|_| LcLz2Error::LongLengthCommand(real_command_bits))?;
             let length_part_1 = chunk_header & 0b11;
             let length_part_2 = *in_it.first().ok_or(LcLz2Error::LongLength)?;
             length = (((length_part_1 as usize) << 8) | (length_part_2 as usize)) + 1;

--- a/smwe_rom/src/compression/lc_lz2.rs
+++ b/smwe_rom/src/compression/lc_lz2.rs
@@ -61,7 +61,7 @@ pub fn decompress(input: &[u8]) -> Result<Vec<u8>, LcLz2Error> {
 
         match command {
             Command::DirectCopy => {
-                if length < in_it.len() {
+                if length <= in_it.len() {
                     let (bytes, rest) = in_it.split_at(length);
                     output.extend_from_slice(bytes);
                     in_it = rest;

--- a/smwe_rom/src/compression/lc_rle1.rs
+++ b/smwe_rom/src/compression/lc_rle1.rs
@@ -21,9 +21,11 @@ pub fn decompress(input: &[u8]) -> Result<Vec<u8>, LcRle1Error> {
             break;
         }
         in_it = &in_it[1..];
-        let command = (chunk_header >> 7) & 1;
+        let command = chunk_header >> 7;
+        let length = chunk_header & 0b1111111;
+
         let command = Command::try_from(command).map_err(|_| LcRle1Error::Command(command))?;
-        let length = (chunk_header & 0b01111111) as usize + 1;
+        let length = length as usize + 1;
 
         match command {
             Command::DirectCopy => {

--- a/smwe_rom/src/compression/lc_rle1.rs
+++ b/smwe_rom/src/compression/lc_rle1.rs
@@ -29,7 +29,7 @@ pub fn decompress(input: &[u8]) -> Result<Vec<u8>, LcRle1Error> {
 
         match command {
             Command::DirectCopy => {
-                if length < in_it.len() {
+                if length <= in_it.len() {
                     let (bytes, rest) = in_it.split_at(length);
                     output.extend_from_slice(bytes);
                     in_it = rest;

--- a/smwe_rom/src/error.rs
+++ b/smwe_rom/src/error.rs
@@ -25,7 +25,7 @@ pub enum AddressError {
 pub enum LcRle1Error {
     #[error("Wrong command: {0:03b}")]
     Command(u8),
-    #[error("Direcy Copy - Cannot read {0} bytes")]
+    #[error("Direct Copy - Cannot read {0} bytes")]
     DirectCopy(usize),
     #[error("Byte Fill - Cannot read byte")]
     ByteFill,
@@ -39,7 +39,7 @@ pub enum LcLz2Error {
     LongLengthCommand(u8),
     #[error("Long Length - Cannot read second byte of header")]
     LongLength,
-    #[error("Direcy Copy - Cannot read {0} bytes")]
+    #[error("Direct Copy - Cannot read {0} bytes")]
     DirectCopy(usize),
     #[error("Byte Fill - Cannot read byte")]
     ByteFill,

--- a/smwe_rom/src/error.rs
+++ b/smwe_rom/src/error.rs
@@ -1,10 +1,11 @@
+use std::ops::Range;
+
 use thiserror::Error;
 
 use crate::snes_utils::{
     addr::{AddrPc, AddrSnes},
     rom_slice::{PcSlice, SnesSlice},
 };
-use std::ops::Range;
 
 // -------------------------------------------------------------------------------------------------
 

--- a/smwe_rom/src/error.rs
+++ b/smwe_rom/src/error.rs
@@ -20,8 +20,36 @@ pub enum AddressError {
 }
 
 #[derive(Debug, Error)]
-#[error("Failed to decompress data: {0}")]
-pub struct DecompressionError(pub &'static str);
+pub enum LcRle1Error {
+    #[error("Wrong command: {0:03b}")]
+    Command(u8),
+    #[error("Direcy Copy - Cannot read {0} bytes")]
+    DirectCopy(usize),
+    #[error("Byte Fill - Cannot read byte")]
+    ByteFill,
+}
+
+#[derive(Debug, Error)]
+pub enum LcLz2Error {
+    #[error("Wrong command: {0:03b}")]
+    Command(u8),
+    #[error("Long Length - Wrong command: {0:03b}")]
+    LongLengthCommand(u8),
+    #[error("Long Length - Cannot read second byte of header")]
+    LongLength,
+    #[error("Direcy Copy - Cannot read {0} bytes")]
+    DirectCopy(usize),
+    #[error("Byte Fill - Cannot read byte")]
+    ByteFill,
+    #[error("Word Fill - Cannot read word")]
+    WordFill,
+    #[error("Increasing Fill - Cannot read byte")]
+    IncreasingFill,
+    #[error("Repeat - Cannot read offset")]
+    Repeat,
+    #[error("Double Long Length")]
+    DoubleLongLength,
+}
 
 #[derive(Debug, Error)]
 pub enum GfxTileError {
@@ -116,7 +144,7 @@ pub enum GfxFileParseError {
     #[error("Isolating GFX data:\n- {0}")]
     IsolatingData(RomError),
     #[error("Decompressing GFX data:\n- {0}")]
-    DecompressingData(DecompressionError),
+    DecompressingData(LcLz2Error),
     #[error("Parsing GFX tile")]
     ParsingTile,
 }
@@ -145,7 +173,7 @@ pub enum LevelParseError {
     #[error("Parsing Layer2 object data:\n- {0}")]
     Layer2Read(RomError),
     #[error("Reading Layer2 background:\n- {0}")]
-    Layer2BackgroundRead(DecompressionError),
+    Layer2BackgroundRead(LcRle1Error),
     #[error("Reading Sprite data:\n- {0}")]
     SpriteRead(RomError),
 }

--- a/smwe_rom/src/error.rs
+++ b/smwe_rom/src/error.rs
@@ -4,6 +4,7 @@ use crate::snes_utils::{
     addr::{AddrPc, AddrSnes},
     rom_slice::{PcSlice, SnesSlice},
 };
+use std::ops::Range;
 
 // -------------------------------------------------------------------------------------------------
 
@@ -46,7 +47,9 @@ pub enum LcLz2Error {
     #[error("Increasing Fill - Cannot read byte")]
     IncreasingFill,
     #[error("Repeat - Cannot read offset")]
-    Repeat,
+    RepeatIncomplete,
+    #[error("Repeat - Range ({}..{}) out of bounds (out buffer size: {1})", .0.start, .0.end)]
+    RepeatRangeOutOfBounds(Range<usize>, usize),
     #[error("Double Long Length")]
     DoubleLongLength,
 }

--- a/smwe_rom/src/graphics/palette.rs
+++ b/smwe_rom/src/graphics/palette.rs
@@ -198,13 +198,13 @@ impl ColorPalettes {
     }
 
     pub fn get_level_palette(&self, header: &PrimaryHeader) -> Result<SpecificLevelColorPalette, ColorPaletteError> {
-        self.lv_specific_set.get_level_palette(header, &self)
+        self.lv_specific_set.get_level_palette(header, self)
     }
 
     pub fn get_submap_palette(
         &self, submap: usize, ow_state: OverworldState,
     ) -> Result<SpecificOverworldColorPalette, ColorPaletteError> {
-        self.ow_specific_set.get_submap_palette(submap, ow_state, &self)
+        self.ow_specific_set.get_submap_palette(submap, ow_state, self)
     }
 }
 

--- a/smwe_rom/src/level/background.rs
+++ b/smwe_rom/src/level/background.rs
@@ -1,4 +1,4 @@
-use crate::{compression::lc_rle1, error::DecompressionError};
+use crate::{compression::lc_rle1, error::LcRle1Error};
 
 pub type BackgroundTileID = u8;
 
@@ -8,7 +8,7 @@ pub struct BackgroundData {
 }
 
 impl BackgroundData {
-    pub fn read_from(input: &[u8]) -> Result<Self, DecompressionError> {
+    pub fn read_from(input: &[u8]) -> Result<Self, LcRle1Error> {
         let tile_ids = lc_rle1::decompress(input)?;
         Ok(Self { tile_ids })
     }

--- a/src/ui/dev_utils/address_converter.rs
+++ b/src/ui/dev_utils/address_converter.rs
@@ -76,8 +76,8 @@ impl UiAddressConverter {
     }
 
     fn conversions(&mut self, ui: &Ui) {
-        self.address_input(&ui, ConvDir::PcToSnes);
-        self.address_input(&ui, ConvDir::SnesToPc);
+        self.address_input(ui, ConvDir::PcToSnes);
+        self.address_input(ui, ConvDir::SnesToPc);
         if !self.text_error.is_empty() {
             ui.text_colored(color::TEXT_ERROR, self.text_error.to_str());
         }


### PR DESCRIPTION
As I searched for the fix for parsing the GFX, I noticed that the GFX file documentation lists incorrect formats. [Here](https://github.com/galaxyhaxz/smw-src/blob/master/document/graphics.txt) is a better doc.

It turns out that the previous documentation listed the formats in which the GFX files were used by SNES's GPU, rather than the formats in which they are stored in the ROM. Adding support for 3BPP and replacing Mode7 with 4BPP fixed the issue.